### PR TITLE
removed memset that caused segmentation fault on disconnect

### DIFF
--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -2341,7 +2341,6 @@ void G_Client_Disconnect(int32_t clientNum) {
     }
 
     trap_UnlinkEntity(ent);
-    memset(ent, 0, sizeof(*ent));
     ent->s.modelindex = 0;
     ent->inuse = qfalse;
     ent->classname = "disconnected";


### PR DESCRIPTION
#58

This was one of the memsets that was originally incorrect (due to sizeof(ent) rather than sizeof(*ent) ) that, when fixed, caused a segfault. Since the original code only memset the size of an int to zero, I don't see any harm in removing it altogether.
