### PR TITLE
Fix builds on Ubuntu Trusty (14)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 # GNU Make required
 #
 
+CFLAGS += -std=gnu11
+
 COMPILE_PLATFORM=$(shell uname|sed -e s/_.*//|tr '[:upper:]' '[:lower:]'|sed -e 's/\//_/g')
 
 COMPILE_ARCH=$(shell uname -m | sed -e s/i.86/i386/)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-#The Last Outpost RPG-X EF Clean-up Project
+# The Last Outpost RPG-X EF Clean-up Project
 
 [![Join the chat at https://gitter.im/solarisstar/rpgxEF](https://badges.gitter.im/solarisstar/rpgxEF.svg)](https://gitter.im/solarisstar/rpgxEF?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 This repository was forked from the UBerGames rpgxEF repository located here: https://github.com/UberGames/rpgxEF.
 This is an attempt by The Last Outpost (www.last-outpost.net) to clean up the source code in order to get it to 
 build with Visual Studio 2015 and be able to maintain it more easily in the future.
 
-#Installing Instructions
+# Installing Instructions
 
 ## For Beginners
 * Make sure you are running on a computer or Virtual Machine (VM) with Linux Ubuntu 64-bits (or variants such as Xubuntu).
@@ -48,7 +48,7 @@ and then copying the following files from your VM onto your computer:
 * Git Pull this repository onto a Ubuntu flavoured Linux machine or VM
 * Terminal to the repository directory and run: ./install_deps.sh. This will install all development dependencies for running make
 * Run make to build for Linux 64 bits, find the output files in the build directory
-  * Run ./make-i368.sh for building the Linux 32 bits variant
+  * Run ./make-i386.sh for building the Linux 32 bits variant
   * Run ./cross-make-mingw.sh for building the Windows 32 bits variant
   * Run ./cross-make-mingw64.sh for building the Windows 64 bits variant
 * Install a fresh copy of the RPG-X Standard Edition from TLO: http://www.last-outpost.net/rpgx/ and put the build files in the correct directory as described below, then run executable file to launch RPG-X EF
@@ -62,7 +62,7 @@ and then copying the following files from your VM onto your computer:
     * build/release-PLATFORM-ARCH/rpgxEF/qagameARCH
     * build/release-PLATFORM-ARCH/rpgxEF/cgameARCH
 
-* Be sure to run the game with the following cvars: +set vm_game 0 +set vm_ui 0 +set vm_cgame 0 +set fs_game RPG-X2
+* ~~Be sure to run the game with the following cvars: +set vm_game 0 +set vm_ui 0 +set vm_cgame 0 +set fs_game RPG-X2~~ UPDATE: cvars should no longer be required.
 
-#Contact Information
+# Contact Information
 Contact Telex Ferra or Martin Thompson on www.last-outpost.net/forum for more information about this repository.

--- a/cross-make-mingw.sh
+++ b/cross-make-mingw.sh
@@ -2,6 +2,7 @@
 
 CMD_PREFIX="i586-mingw32msvc i686-w64-mingw32";
 
+# Set CC to correct compiler
 if [ "X$CC" = "X" ]; then
     for check in $CMD_PREFIX; do
         full_check="${check}-gcc"
@@ -11,6 +12,7 @@ if [ "X$CC" = "X" ]; then
     done
 fi
 
+# Set WINDRES to correct compiler
 if [ "X$WINDRES" = "X" ]; then
     for check in $CMD_PREFIX; do
         full_check="${check}-windres"
@@ -20,9 +22,11 @@ if [ "X$WINDRES" = "X" ]; then
     done
 fi
 
+# Add mingw header files to PATH
 for check in $CMD_PREFIX; do
-    if [[ ! $PATH == *"${check}"* ]]; then
-	export PATH="/usr/${check}:$PATH"
+    INCLUDE_DIR="/usr/${check}";
+    if [ ! $PATH = *"$INCLUDE_DIR"* ] && [ -d "$INCLUDE_DIR" ] ; then
+	    export PATH="$INCLUDE_DIR:$PATH"
     fi
 done
 

--- a/cross-make-mingw.sh
+++ b/cross-make-mingw.sh
@@ -20,6 +20,12 @@ if [ "X$WINDRES" = "X" ]; then
     done
 fi
 
+for check in $CMD_PREFIX; do
+    if [[ ! $PATH == *"${check}"* ]]; then
+	export PATH="/usr/${check}:$PATH"
+    fi
+done
+
 if [ "X$WINDRES" = "X" -o "X$CC" = "X" ]; then
     echo "Error: Must define or find WINDRES and CC"
     exit 1

--- a/cross-make-mingw64.sh
+++ b/cross-make-mingw64.sh
@@ -20,6 +20,12 @@ if [ "X$WINDRES" = "X" ]; then
     done
 fi
 
+for check in $CMD_PREFIX; do
+    if [[ ! $PATH == *"${check}"* ]]; then
+	export PATH="/usr/${check}:$PATH"
+    fi
+done
+
 if [ "X$WINDRES" = "X" -o "X$CC" = "X" ]; then
     echo "Error: Must define or find WINDRES and CC"
     exit 1

--- a/cross-make-mingw64.sh
+++ b/cross-make-mingw64.sh
@@ -2,6 +2,7 @@
 
 CMD_PREFIX="amd64-mingw32msvc x86_64-w64-mingw32";
 
+# Set CC to correct compiler
 if [ "X$CC" = "X" ]; then
     for check in $CMD_PREFIX; do
         full_check="${check}-gcc"
@@ -11,6 +12,7 @@ if [ "X$CC" = "X" ]; then
     done
 fi
 
+# Set WINDRES to correct compiler
 if [ "X$WINDRES" = "X" ]; then
     for check in $CMD_PREFIX; do
         full_check="${check}-windres"
@@ -20,9 +22,11 @@ if [ "X$WINDRES" = "X" ]; then
     done
 fi
 
+# Add mingw header files to PATH
 for check in $CMD_PREFIX; do
-    if [[ ! $PATH == *"${check}"* ]]; then
-	export PATH="/usr/${check}:$PATH"
+    INCLUDE_DIR="/usr/${check}";
+    if [ ! $PATH = *"$INCLUDE_DIR"* ] && [ -d "$INCLUDE_DIR" ] ; then
+	    export PATH="$INCLUDE_DIR:$PATH"
     fi
 done
 

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -15,7 +15,7 @@ apt-get install -y libglu1-mesa-dev
 apt-get install -y libmad0-dev
 apt-get install -y libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev
 apt-get install -y libogg-dev
-apt-get install -y mingw-w64
+apt-get install -y mingw-w64 gcc-multilib
 
 echo "You should now be setup to run the build scripts for RPG-X."
 echo "Post on our gitter: https://gitter.im/solarisstar/rpgxEF or contact solarisstar / Telex Ferra if you need any assistance."


### PR DESCRIPTION
Added missing dependencies, build flags (for gcc 4.8) and compiler include paths (for mingw) to fix builds on Ubuntu Trusty (14)

This fixes all missing dependencies and other stuff for building on Ubuntu trusty in preperation for building using Travis CI (their build vm's run Ubuntu Trusty).