### PR TITLE
hyperspanner fixes

### DIFF
--- a/code/game/g_combat.c
+++ b/code/game/g_combat.c
@@ -1430,42 +1430,12 @@ extern void InitBBrush(gentity_t *ent);
 extern void SP_misc_model_breakable(gentity_t* self);
 
 void G_Repair(gentity_t *ent, gentity_t *tr_ent, float rate) {
-    float		distance;
-    vec3_t		help, forward;
-    int			i;
-    float		max = 0;
-
     // if count isn't 0 the breakable is not damaged and if target is no breakable it does not make sense to go on
     if (tr_ent->count != 0 || strstr(tr_ent->classname, "breakable") == NULL) {
         return;
     }
 
     if (!(tr_ent->spawnflags & 256)) { // no REPAIRABLE flag set
-        return;
-    }
-
-    // check if player is near the breakable
-    if (tr_ent->spawnflags & 512) {
-        VectorSubtract(tr_ent->s.angles2, ent->r.currentOrigin, help);
-        max = tr_ent->n00bCount;
-    } else {
-        VectorSubtract(tr_ent->s.origin, ent->r.currentOrigin, help);
-        for (i = 0; i < 3; i++) {
-            if (tr_ent->r.maxs[i] > max) {
-                max = tr_ent->r.maxs[i];
-            }
-        }
-    }
-    distance = VectorLength(help);
-
-    //G_Printf("goodDst=%f, curDst=%f\n", 80 + max, distance);
-    if (distance > 80 + max) {
-        return;
-    }
-
-    // check if the player is facing it
-    AngleVectors(ent->client->ps.viewangles, forward, NULL, NULL);
-    if (DotProduct(help, forward) < 0.4) {
         return;
     }
 


### PR DESCRIPTION
Tweak RPG-X hyperspanner and repair functionality to make them easier to use. Notable changes:

- G_Repair has been refactored to remove checks for the player's distance and angle towards the repairable. These are only relevant to repairs made with the hyperspanner and the checks should be performed there. This change opens up the possibility for other uses for repair entities such as usable entities that can call G_Repair on an a repairable entity even if the player isn't near it.
- Remove checks to ensure there are no objects between the player using a hyperspanner and the repairable entity. Given the short radius of the hyperspanner and given how often this accidentally dropped repair attempts if a user got too close to an object, it seemed more trouble than it's worth. The worst that can happen is a user repairs something through a wall.
- Modify WP_FireHyperspanner to ignore repairables in range that aren't damage. Before this PR the hyperspanner would lock onto the nearest repairable, regardless of whether or not it was actually broken. This would cause the hyperspanner to not work if two repairable entities were close together where one was broken and the other wasn't. (e.g. back of engineering on rpg_voy4)
- Rewrite the calculation to determine if a user is facing an object. **The previous calculation was incorrect, often producing large angles greater than 360 degrees, and was likely the source of many dropped repair attempts.**After this change, a repairable must be within a 45 degree cone around the player's crosshairs.
- Lastly, greatly reduce the radius of the hyperspanner. The previous radius of 512 is quite large and would allow for repairing entities from across a room. It only seemed like the radius was too short before because of the erroneous angle calculation.
