### PR TITLE
Turbolift fixes

### DIFF
--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -4905,26 +4905,23 @@ static void Cmd_Turbolift_f(gentity_t* ent)
     gentity_t *otherLift = NULL;
     playerState_t *ps;
 
-    if (!ent->client)
+    if (!ent->client) {
         return;
+    }
 
     ps = &ent->client->ps;
 
-    if (ent->client->sess.sessionTeam == TEAM_SPECTATOR)
+    if (ent->client->sess.sessionTeam == TEAM_SPECTATOR) {
         return;
+    }
 
     if (ps->stats[STAT_HEALTH] <= 0) {
         return;
     }
 
-    // Previous versions of RPG-X included a bug that caused the deck command to ignore
-    // the first argument and only consider the second. A user would have to type 
-    // /deck 3 3 in order to go to deck 3. This bug is now fixed but multiple maps 
-    // have been built with the old, buggy behavior. Now both variants must be supported
-    // for all time. 
-    // Prefer the second deck number argument if specified, otherwise use the first.
-    int deckIndex = trap_Argc() > 2 ? 2 : 1;
-    trap_Argv(deckIndex, arg, sizeof(arg));
+    // The deck command takes a second, unused "lift number" parameter.
+    // If we ever implement that functionality, it's available at index 2.
+    trap_Argv(1, arg, sizeof(arg));
 
     if (!arg[0]) {
         trap_SendServerCommand(ent - g_entities, "print \"You must specify a deck\n\" ");

--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -4917,10 +4917,16 @@ static void Cmd_Turbolift_f(gentity_t* ent)
         return;
     }
 
-    trap_Argv(1, arg, sizeof(arg));
+    // Previous versions of RPG-X included a bug that caused the deck command to ignore
+    // the first argument and only consider the second. A user would have to type 
+    // /deck 3 3 in order to go to deck 3. This bug is now fixed but multiple maps 
+    // have been built with the old, buggy behavior. Now both variants must be supported
+    // for all time. 
+    // Prefer the second deck number argument if specified, otherwise use the first.
+    int deckIndex = trap_Argc() > 2 ? 2 : 1;
+    trap_Argv(deckIndex, arg, sizeof(arg));
 
-    if (!arg[0])
-    {
+    if (!arg[0]) {
         trap_SendServerCommand(ent - g_entities, "print \"You must specify a deck\n\" ");
         return;
     }

--- a/code/ui/ui_turbolift.c
+++ b/code/ui/ui_turbolift.c
@@ -138,7 +138,12 @@ static void M_Turbolift_Event(void* ptr, int notification)
     case ID_ENGAGE:		// Active only if a deck has been chosen
         if (notification == QM_ACTIVATED) {
             UI_ForceMenuOff();
-            trap_Cmd_ExecuteText(EXEC_APPEND, va("deck %i %i", s_turbolift.liftNum, s_turbolift.deckData[s_turbolift.chosenDeck].deckNum));
+            trap_Cmd_ExecuteText(
+                EXEC_APPEND, 
+                va(
+                    "deck %i %i", 
+                    s_turbolift.deckData[s_turbolift.chosenDeck].deckNum,
+                    s_turbolift.liftNum));
         }
         break;
     }


### PR DESCRIPTION
Fix turbolift entities currently broken on develop.

The /deck command was originally intended to have a "lift number" parameter as the first argument and the deck number as the second. The former was never implemented (the existing code selects a lift on the target deck at random) so I've swapped the argument order so that the lift number is optional and comes second. Since the lift number isn't considered, it will be effectively ignored. 

