### PR TITLE
Feature/Roll Command

### DIFF
--- a/code/cgame/cg_consolecmds.c
+++ b/code/cgame/cg_consolecmds.c
@@ -893,4 +893,5 @@ void CG_InitConsoleCommands(void) {
     trap_AddCommand("generatePrecacheFile");
 
     trap_AddCommand("roll");
+    trap_AddCommand("proll");
 }

--- a/code/cgame/cg_consolecmds.c
+++ b/code/cgame/cg_consolecmds.c
@@ -824,7 +824,7 @@ void CG_InitConsoleCommands(void) {
 
     trap_AddCommand("me");
     trap_AddCommand("meLocal");
-
+    
     trap_AddCommand("mapsList");
 
     /*
@@ -892,4 +892,6 @@ void CG_InitConsoleCommands(void) {
 
     /* precacheFile */
     trap_AddCommand("generatePrecacheFile");
+
+    trap_AddCommand("roll");
 }

--- a/code/cgame/cg_consolecmds.c
+++ b/code/cgame/cg_consolecmds.c
@@ -824,7 +824,6 @@ void CG_InitConsoleCommands(void) {
 
     trap_AddCommand("me");
     trap_AddCommand("meLocal");
-    
     trap_AddCommand("mapsList");
 
     /*

--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -5162,6 +5162,52 @@ static void Cmd_RollAction_f(gentity_t* ent)
         ent->client->pers.netname, dieResult, dieMax));
 }
 
+/*
+================ =
+Cmd_PrivateRollAction_f
+
+Simple die roll command - private version
+
+/proll [dieSize]
+================ =
+*/
+
+// Private Dice Roll Parameters
+#define PRIVATE_ROLL_DIE_MINIMUM_SIDES ROLL_DIE_MINIMUM_SIDES
+#define PRIVATE_ROLL_DIE_DEFAULT_SIDES ROLL_DIE_DEFAULT_SIDES
+#define PRIVATE_ROLL_DIE_MAXIMUM_SIDES ROLL_DIE_MAXIMUM_SIDES
+
+static void Cmd_PrivateRollAction_f(gentity_t * ent)
+{
+    if (!ent->client) {
+        return;
+    }
+
+    int dieMax = PRIVATE_ROLL_DIE_DEFAULT_SIDES;
+
+    // If an argument provided, use that as die size
+    if (trap_Argc() > 1) {
+        char arg[MAX_TOKEN_CHARS];
+        trap_Argv(1, arg, sizeof(arg));
+        dieMax = atoi(arg);
+
+        // Check die size within range
+        if (dieMax < PRIVATE_ROLL_DIE_MINIMUM_SIDES || dieMax > PRIVATE_ROLL_DIE_MAXIMUM_SIDES) {
+            trap_SendServerCommand(ent - g_entities,
+                va("print \"roll: Choose a die size between %d and %d (inclusive)\n\"",
+                    PRIVATE_ROLL_DIE_MINIMUM_SIDES, PRIVATE_ROLL_DIE_MAXIMUM_SIDES));
+            return;
+        }
+    }
+
+    // "Roll Die"
+    int dieResult = irandom(1, dieMax);
+
+    // Send result to calling client only
+    trap_SendServerCommand(ent - g_entities, va("print \"%s" S_COLOR_MAGENTA " rolled %u on a d%u\n\"",
+        ent->client->pers.netname, dieResult, dieMax));
+}
+
 static void Cmd_MapsList_f(gentity_t *ent)
 {
     char	mapList[1024];
@@ -7632,6 +7678,8 @@ void G_Client_Command(int clientNum)
         Cmd_MeActionLocal_f(ent);
     else if (Q_stricmp(cmd, "roll") == 0)
         Cmd_RollAction_f(ent);
+    else if (Q_stricmp(cmd, "proll") == 0)
+        Cmd_PrivateRollAction_f(ent);
     else if (Q_stricmp(cmd, "mapsList") == 0)
         Cmd_MapsList_f(ent);
     else if (Q_stricmp(cmd, "drop") == 0)  // RPG-X | Marcin | 03/12/2008

--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -5110,8 +5110,17 @@ static void Cmd_MeActionLocal_f(gentity_t* ent)
     }
 }
 
-// Dice Roll Parameters
+/*
+=================
+Cmd_RollAction_f
 
+Simple die roll command
+
+/roll [dieSize]
+=================
+*/
+
+// Dice Roll Parameters
 #define ROLL_DIE_MINIMUM_SIDES 2
 #define ROLL_DIE_DEFAULT_SIDES 20
 #define ROLL_DIE_MAXIMUM_SIDES 1000
@@ -5149,7 +5158,8 @@ static void Cmd_RollAction_f(gentity_t* ent)
     int dieResult = irandom(1, dieMax);
 
     // Broadcast Result
-    trap_SendServerCommand(-1, va("print \"%s" S_COLOR_WHITE " rolled %u on a d%u\n\"", ent->client->pers.netname, dieResult, dieMax));
+    trap_SendServerCommand(-1, va("print \"%s" S_COLOR_WHITE " rolled %u on a d%u\n\"",
+        ent->client->pers.netname, dieResult, dieMax));
 }
 
 static void Cmd_MapsList_f(gentity_t *ent)

--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -5110,6 +5110,34 @@ static void Cmd_MeActionLocal_f(gentity_t* ent)
     }
 }
 
+// Common elements of die rolling commands
+// Returns a pair of ints, {die result, die size}
+// Returns NULL if invalid argument provided
+static int* RollAction_Common(gentity_t* ent, int dieMin, int dieMax, int dieDefault)
+{
+    int dieSize = dieDefault;
+
+    // If an argument provided, use that as die size
+    if (trap_Argc() > 1) {
+        char arg[MAX_TOKEN_CHARS];
+        trap_Argv(1, arg, sizeof(arg));
+        dieSize = atoi(arg);
+
+        // Check die size within range
+        if (dieSize < dieMin || dieSize > dieMax) {
+            return NULL;
+        }
+    }
+
+    int* pair = malloc(2 * sizeof(int));
+
+    // "Roll Die"
+    pair[0] = irandom(1, dieSize);
+    pair[1] = dieSize;
+
+    return pair;
+}
+
 /*
 =================
 Cmd_RollAction_f
@@ -5137,39 +5165,36 @@ static void Cmd_RollAction_f(gentity_t* ent)
         return;
     }
 
-    int dieMax = ROLL_DIE_DEFAULT_SIDES;
-
-    // If an argument provided, use that as die size
-    if (trap_Argc() > 1) {
-        char arg[MAX_TOKEN_CHARS];
-        trap_Argv(1, arg, sizeof(arg));
-        dieMax = atoi(arg);
-
-        // Check die size within range
-        if (dieMax < ROLL_DIE_MINIMUM_SIDES || dieMax > ROLL_DIE_MAXIMUM_SIDES) {
-            trap_SendServerCommand(ent - g_entities,
-                va("print \"roll: Choose a die size between %d and %d (inclusive)\n\"",
-                    ROLL_DIE_MINIMUM_SIDES, ROLL_DIE_MAXIMUM_SIDES));
-            return;
-        }
-    }
-
     // "Roll Die"
-    int dieResult = irandom(1, dieMax);
+    int* dieResult = RollAction_Common(ent, ROLL_DIE_MINIMUM_SIDES, ROLL_DIE_MAXIMUM_SIDES, ROLL_DIE_DEFAULT_SIDES);
 
-    // Broadcast Result
-    trap_SendServerCommand(-1, va("print \"%s" S_COLOR_WHITE " rolled %u on a d%u\n\"",
-        ent->client->pers.netname, dieResult, dieMax));
+    if (dieResult) {
+        // Broadcast Result
+        trap_SendServerCommand(-1,
+            va("print \"%s" S_COLOR_WHITE " rolled %u on a d%u\n\"",
+                ent->client->pers.netname, dieResult[0], dieResult[1])
+        );
+        free(dieResult);
+    }
+    else {
+        // Invalid argument, print usage
+        trap_SendServerCommand(ent - g_entities,
+            va("print \"roll: Choose a die size between %d and %d (inclusive)\n\"",
+                ROLL_DIE_MINIMUM_SIDES, ROLL_DIE_MAXIMUM_SIDES)
+        );
+    }
+    
+    
 }
 
 /*
-================ =
+=================
 Cmd_PrivateRollAction_f
 
 Simple die roll command - private version
 
 /proll [dieSize]
-================ =
+=================
 */
 
 // Private Dice Roll Parameters
@@ -5183,29 +5208,24 @@ static void Cmd_PrivateRollAction_f(gentity_t * ent)
         return;
     }
 
-    int dieMax = PRIVATE_ROLL_DIE_DEFAULT_SIDES;
-
-    // If an argument provided, use that as die size
-    if (trap_Argc() > 1) {
-        char arg[MAX_TOKEN_CHARS];
-        trap_Argv(1, arg, sizeof(arg));
-        dieMax = atoi(arg);
-
-        // Check die size within range
-        if (dieMax < PRIVATE_ROLL_DIE_MINIMUM_SIDES || dieMax > PRIVATE_ROLL_DIE_MAXIMUM_SIDES) {
-            trap_SendServerCommand(ent - g_entities,
-                va("print \"roll: Choose a die size between %d and %d (inclusive)\n\"",
-                    PRIVATE_ROLL_DIE_MINIMUM_SIDES, PRIVATE_ROLL_DIE_MAXIMUM_SIDES));
-            return;
-        }
-    }
-
     // "Roll Die"
-    int dieResult = irandom(1, dieMax);
+    int* dieResult = RollAction_Common(ent, PRIVATE_ROLL_DIE_MINIMUM_SIDES, PRIVATE_ROLL_DIE_MAXIMUM_SIDES, PRIVATE_ROLL_DIE_DEFAULT_SIDES);
 
-    // Send result to calling client only
-    trap_SendServerCommand(ent - g_entities, va("print \"%s" S_COLOR_MAGENTA " rolled %u on a d%u\n\"",
-        ent->client->pers.netname, dieResult, dieMax));
+    if (dieResult) {
+        // Send result to calling client
+        trap_SendServerCommand(ent - g_entities,
+            va("print \"%s" S_COLOR_MAGENTA " rolled %u on a d%u\n\"",
+                ent->client->pers.netname, dieResult[0], dieResult[1])
+        );
+        free(dieResult);
+    }
+    else {
+        // Invalid argument, print usage
+        trap_SendServerCommand(ent - g_entities,
+            va("print \"proll: Choose a die size between %d and %d (inclusive)\n\"",
+                PRIVATE_ROLL_DIE_MINIMUM_SIDES, PRIVATE_ROLL_DIE_MAXIMUM_SIDES)
+        );
+    }
 }
 
 static void Cmd_MapsList_f(gentity_t *ent)


### PR DESCRIPTION
Simple die roll command to easily incorporate randomisation into roleplay activities, such as using the RPG-X Skill System (as opposed to TLO's current solution of a discord bot command to transmit random numbers to server console).

Usage: `/roll [dieSize]`
Default set to d20. Acceptable range 2 <= dieSize <= 1000.
Choice of 1000 is a bit arbitrary, though I doubt it'll ever see sizes that big.